### PR TITLE
实现自动复制容器内文件到映射的宿主机目录

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,18 @@ ADD . ./
 #增加缺失的包，移除没用的包
 RUN go mod tidy
 
-RUN go build -o Gin_HomeNavigation .
+RUN go build -o main .
 
-FROM scratch
+FROM alpine:latest
 
-COPY --from=builder go/src/Gin_HomeNavigation/conf /conf
-COPY --from=builder go/src/Gin_HomeNavigation/views /views
-COPY --from=builder go/src/Gin_HomeNavigation/Gin_HomeNavigation /
+COPY --from=builder go/src/Gin_HomeNavigation/conf /app/conf
+COPY --from=builder go/src/Gin_HomeNavigation/views /app/views
+COPY --from=builder go/src/Gin_HomeNavigation/main /app
+COPY --from=builder go/src/Gin_HomeNavigation/start.sh /
 
-ENTRYPOINT  ["./Gin_HomeNavigation"]
+RUN mkdir /datas&&cp -ra /app/* /datas&&rm -rf /app
+
+VOLUME /app
+RUN chmod +x /start.sh
+
+ENTRYPOINT  ["/start.sh"]

--- a/conf/config.json
+++ b/conf/config.json
@@ -5,7 +5,7 @@
     "Title": "Cloud Services"
   },
   "SoftWare": {
-    "port": "8100",
+    "port": "80",
     "password": "",
     "Mode": "W"
   },

--- a/dataSource/Config_Conn.go
+++ b/dataSource/Config_Conn.go
@@ -19,7 +19,7 @@ func LoadConfig() *model.Config {
 	config := model.Config{}
 
 	// 打开文件
-	file ,err := os.Open("conf/config.json")
+	file ,err := os.Open("/app/conf/config.json")
 	if err != nil {
 		// 打开文件时发生错误
 		log.Println("An error occurred while opening the file")

--- a/main.go
+++ b/main.go
@@ -26,13 +26,13 @@ func main() {
 	//加载静态文件
 	{
 		// HTML文件
-		r.LoadHTMLFiles("./views/index.html")
+		r.LoadHTMLFiles("/app/views/index.html")
 		// CSS
-		r.Static("css", "views/css")
+		r.Static("css", "/app/views/css")
 		// JS
-		r.Static("js", "views/js")
+		r.Static("js", "/app/views/js")
 		// IMG
-		r.Static("img", "views/img")
+		r.Static("img", "/app/views/img")
 
 	}
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cp -ra /datas/* /app
+rm -r /datas
+ln -s /app /datas
+/app/main


### PR DESCRIPTION
# 调整了程序名称及启动目录

1. 将主程序文件名修改为`main`
2. 将所有文件放在`/app`目录中
3. 新增`/start.sh`，容器启动时先启动此脚本，然后通过此脚本启动`main`程序，同时也是通过此脚本实现自动复制容器内文件到映射的宿主机目录
4. 修改容器内监听端口为`80`，反正运行时需要再次映射，所有为了简化`docker run`命令，改为`80`.
忘记更新`readme.md`。

# 一键运行
```bash
docker run --restart=unless-stopped -v /你的存储目录:/app -p 6666:80 nuanxinqing123/home_navigation:latest
```

另：`docker-compose`文件可以删掉了
